### PR TITLE
fix: return HCP exceptions as StorageErrors

### DIFF
--- a/hcp/src/main/scala/com/avast/clients/storage/hcp/HcpRestStorageBackend.scala
+++ b/hcp/src/main/scala/com/avast/clients/storage/hcp/HcpRestStorageBackend.scala
@@ -67,7 +67,7 @@ class HcpRestStorageBackend[F[_]: Sync: ContextShift](baseUrl: Uri, username: St
       }
 
     } catch {
-      case NonFatal(e) => F.raiseError(e)
+      case NonFatal(e) => F.pure(Left(StorageException.InvalidResponseException(0, "", "General exception in client", e)))
     }
   }
 
@@ -92,7 +92,7 @@ class HcpRestStorageBackend[F[_]: Sync: ContextShift](baseUrl: Uri, username: St
           }
         }
     } catch {
-      case NonFatal(e) => F.raiseError(e)
+      case NonFatal(e) => F.pure(Left(StorageException.InvalidResponseException(0, "", "General exception in client", e)))
     }
   }
 


### PR DESCRIPTION
This causes `withFallbackIfError` to work properly when HCP is down.